### PR TITLE
table service with generic out result

### DIFF
--- a/play/Naylah.ConsoleAspNetCore3/Controllers/PersonControllerV2.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Controllers/PersonControllerV2.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Query;
+using Microsoft.AspNetCore.Mvc;
+using Naylah.ConsoleAspNetCore.Customizations;
+using Naylah.ConsoleAspNetCore.DTOs;
+using Naylah.ConsoleAspNetCore.Entities;
+using Naylah.Data;
+using Naylah.Data.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Naylah.ConsoleAspNetCore.Controllers
+{
+    [Route("api/[controller]"), ApiController]
+    public class PersonControllerV2 : ControllerBase
+    {
+        private readonly PersonServiceV2 tableDataService;
+
+        public PersonControllerV2(
+            PersonServiceV2 tableDataService)
+        {
+            this.tableDataService = tableDataService;
+        }
+
+        [HttpGet("")]
+        public IEnumerable<PersonGetRequest> GetPeople()
+        {
+            return tableDataService.GetAll<PersonGetRequest>();
+        }
+
+        [HttpPost("SameType")]
+        public async Task<PersonPostRequest> PostReturningSameType(
+            [FromBody] PersonPostRequest person)
+        {
+            return await tableDataService.UpsertAsync(person);
+        }
+
+        [HttpPost("OtherType")]
+        public async Task<PersonGetRequest> PostReturningOtherType(
+            [FromBody] PersonPostRequest person)
+        {
+            return await tableDataService.UpsertAsync<PersonPostRequest, PersonGetRequest>(person);
+        }
+    }
+}

--- a/play/Naylah.ConsoleAspNetCore3/Customizations/AppTableDataService.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Customizations/AppTableDataService.cs
@@ -1,4 +1,5 @@
-﻿using Naylah.Data;
+﻿using Naylah.Core.Data.Services;
+using Naylah.Data;
 using Naylah.Data.Access;
 using System;
 using System.Collections.Generic;
@@ -7,6 +8,35 @@ using System.Threading.Tasks;
 
 namespace Naylah.ConsoleAspNetCore.Customizations
 {
+    public class StringTableDataServiceV2<TEntity>
+        : TableDataServiceV2<TEntity, string>
+        where TEntity : class, IEntity<string>, IModifiable, new()
+    {
+        public StringTableDataServiceV2(
+            IRepository<TEntity, string> repository,
+            IUnitOfWork unitOfWork) : base(repository, unitOfWork)
+        {
+        }
+
+        public StringTableDataServiceV2(
+            IRepository<TEntity, string> repository,
+            IUnitOfWork unitOfWork,
+            Domain.Abstractions.IHandler<Notification> notificationsHandler) : base(repository, unitOfWork, notificationsHandler)
+        {
+        }
+
+        protected override Task<TEntity> FindByIdAsync(string identifier)
+        {
+            return FindByAsync(x => x.Id == identifier);
+        }
+
+        protected override Task GenerateId(TEntity entity)
+        {
+            entity.GenerateId();
+            return Task.FromResult(1);
+        }
+    }
+
     public class StringAppTableDataService<TEntity, TModel> : TableDataService<TEntity, TModel, string>
         where TEntity : class, IEntity<string>, IModifiable, IEntityUpdate<TModel>, new()
         where TModel : class, IEntity<string>, new()

--- a/play/Naylah.ConsoleAspNetCore3/Customizations/CustomTableDataController.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Customizations/CustomTableDataController.cs
@@ -9,8 +9,6 @@ using System.Threading.Tasks;
 
 namespace Naylah.ConsoleAspNetCore.Customizations
 {
-
-
     public abstract class CustomTableDataController<TEntity, TModel, TIdentifier> : TableDataController<TEntity, TModel, TIdentifier>
           where TEntity : class, IEntity<TIdentifier>, IModifiable, IEntityUpdate<TModel>, new()
           where TModel : class, IEntity<TIdentifier>, new()

--- a/play/Naylah.ConsoleAspNetCore3/Entities/Person.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Entities/Person.cs
@@ -3,14 +3,32 @@ using Naylah.ConsoleAspNetCore.DTOs;
 using Naylah.Data;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace Naylah.ConsoleAspNetCore.Entities
 {
-    public class Person : IEntity<string>, IModifiable, 
+    public class PersonGetRequest : IEntity<string>
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public DateTimeOffset? CreatedAt { get; set; }
+        public DateTimeOffset? UpdatedAt { get; set; }
+    }
+
+    public class PersonPostRequest : IEntity<string>
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Version { get; set; }
+    }
+
+    public class Person : IEntity<string>, IModifiable,
         IEntityUpdate<Person>,
-        IEntityUpdate<PersonDTO>
+        IEntityUpdate<PersonDTO>,
+        IEntityUpdate<PersonGetRequest>,
+        IEntityUpdate<PersonPostRequest>
     {
         public string Id { get; set; }
         public DateTimeOffset? CreatedAt { get; set; }
@@ -28,6 +46,17 @@ namespace Naylah.ConsoleAspNetCore.Entities
         public void UpdateFrom(PersonDTO source, EntityUpdateOptions options = null)
         {
             Name = source.Name;
+        }
+
+        public void UpdateFrom(PersonGetRequest source, EntityUpdateOptions options = null)
+        {
+
+        }
+
+        public void UpdateFrom(PersonPostRequest source, EntityUpdateOptions options = null)
+        {
+            this.Name = source.Name;
+            this.Version = source.Version;
         }
     }
 }

--- a/play/Naylah.ConsoleAspNetCore3/PersonService.cs
+++ b/play/Naylah.ConsoleAspNetCore3/PersonService.cs
@@ -10,6 +10,15 @@ using System.Threading.Tasks;
 
 namespace Naylah.ConsoleAspNetCore
 {
+    public class PersonServiceV2 : StringTableDataServiceV2<Person>
+    {
+        public PersonServiceV2(
+            IRepository<Person, string> repository,
+            IUnitOfWork unitOfWork) : base(repository, unitOfWork)
+        {
+        }
+    }
+
     public class PersonService : StringAppTableDataService<Person, PersonDTO>
     {
         public PersonService(IUnitOfWork _unitOfWork, IRepository<Person, string> repository) : base(_unitOfWork, repository)

--- a/play/Naylah.ConsoleAspNetCore3/Startup.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Startup.cs
@@ -69,7 +69,7 @@ namespace Naylah.ConsoleAspNetCore
 
                 swagger.AddSecurityRequirement(new OpenApiSecurityRequirement()
                 {
-                    
+
                 });
 
                 //var requiriment = new OpenApiSecurityRequirement();
@@ -92,8 +92,7 @@ namespace Naylah.ConsoleAspNetCore
             services.AddScoped<IUnitOfWork, SomeWorker>();
 
             services.AddScoped<PersonService>();
-
-
+            services.AddScoped<PersonServiceV2>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Core/Naylah.Core/Core/Exceptions/NotAssignableException.cs
+++ b/src/Core/Naylah.Core/Core/Exceptions/NotAssignableException.cs
@@ -1,0 +1,13 @@
+namespace Naylah
+{
+    [System.Serializable]
+    public class NotAssignableException : System.Exception
+    {
+        public NotAssignableException() { }
+        public NotAssignableException(string message) : base(message) { }
+        public NotAssignableException(string message, System.Exception inner) : base(message, inner) { }
+        protected NotAssignableException(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/Core/Naylah.Core/Data/Services/TableDataServiceBase.cs
+++ b/src/Core/Naylah.Core/Data/Services/TableDataServiceBase.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Naylah.Data;
+using Naylah.Data.Access;
+using Naylah.Domain.Abstractions;
+
+namespace Naylah
+{
+    public abstract class TableDataServiceBase<TEntity, TIdentifier>
+        : DataServiceBase
+        where TEntity : class, IEntity<TIdentifier>, IModifiable, new()
+    {
+        internal readonly IRepository<TEntity, TIdentifier> Repository;
+        protected bool UseSoftDelete { get; set; } = false;
+        protected bool NotificationThrowException { get; set; } = false;
+
+        protected internal virtual Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> Ordering { get; set; } =
+            (q) => q.OrderByDescending(x => x.CreatedAt);
+
+        public TableDataServiceBase(
+            IRepository<TEntity, TIdentifier> repository,
+            IUnitOfWork unitOfWork)
+            : base(unitOfWork)
+        {
+            this.Repository = repository;
+        }
+
+        public TableDataServiceBase(
+            IRepository<TEntity, TIdentifier> repository,
+            IUnitOfWork unitOfWork,
+            IHandler<Notification> notificationsHandler)
+            : base(unitOfWork, notificationsHandler)
+        {
+            this.Repository = repository;
+        }
+
+        protected internal virtual IQueryable<TEntity> GetEntities()
+        {
+            return Repository.Entities;
+        }
+
+        protected virtual async Task<TEntity> FindByAsync(Expression<Func<TEntity, bool>> predicate)
+        {
+            return GetEntities().Where(predicate).FirstOrDefault();
+        }
+
+        protected virtual async Task<TEntity> FindByIdAsync(TIdentifier identifier)
+        {
+            return await FindByAsync(x => x.Id.Equals(identifier));
+        }
+
+        protected virtual async Task GenerateId(TEntity entity)
+        {
+            //application id generation...
+        }
+
+        protected virtual bool RaiseNotification(Notification notification)
+        {
+            if (NotificationThrowException)
+            {
+                throw new Exception(notification.Key + " - " + notification.Value);
+            }
+            else
+            {
+                NotificationsHandler.Handle(notification);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Core/Naylah.Core/Data/Services/TableDataServiceV2.cs
+++ b/src/Core/Naylah.Core/Data/Services/TableDataServiceV2.cs
@@ -1,0 +1,362 @@
+using System.Threading.Tasks;
+using System.Linq;
+using Naylah.Data;
+using Naylah.Data.Access;
+using System;
+using Naylah.Data.Extensions;
+using System.Linq.Expressions;
+
+namespace Naylah.Core.Data.Services
+{
+    /// <summary>
+    /// An abstract service that only encapsulates the <typeparamref name="TEntity"/> and the <typeparamref name="TIdentifier"/>
+    /// </summary>
+    /// <remarks>All models must have an <see cref="IEntityUpdate{TModel}"/> implemented on the <typeparamref name="TEntity"/>.</remarks>
+    /// <typeparam name="TEntity">Entity type.</typeparam>
+    /// <typeparam name="TIdentifier">Identifier type.</typeparam>
+    public class TableDataServiceV2<TEntity, TIdentifier>
+        : TableDataServiceBase<TEntity, TIdentifier>
+        where TEntity : class, IEntity<TIdentifier>, IModifiable, new()
+    {
+        /// <summary>
+        /// Method to check if the inferred model is assignable from the <typeparamref name="TEntity"/>.
+        /// </summary>
+        /// <typeparam name="TModel">An implemented <see cref="IEntity{TIdentifier}"/>.</typeparam>
+        /// <returns>true if assignable, otherwise throws <see cref="NotAssignableException"/>.</returns>
+        /// <exception cref="NotAssignableException"><typeparamref name="TModel"/> is not implemented in <typeparamref name="TEntity"/>.</exception>
+        private bool IsModelAssignable<TModel>()
+        {
+            var entityType = typeof(TEntity);
+            var acceptable = entityType.GetInterfaces()
+                .Contains(typeof(IEntityUpdate<TModel>));
+            if (!acceptable)
+            {
+                throw new NotAssignableException($"Cannot assign {nameof(TEntity)} into {nameof(IEntityUpdate<TModel>)}.");
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Dinamically calls the <see cref="IEntityUpdate{TSource}.UpdateFrom(TSource, EntityUpdateOptions)"/> method.
+        /// </summary>
+        /// <param name="baseEntity">Entity to be updated.</param>
+        /// <param name="model">Model to update the entity from.</param>
+        /// <param name="upsertType">Upsert type.</param>
+        /// <typeparam name="TModel">An implemented <see cref="IEntity{TIdentifier}"/>.</typeparam>
+        /// <returns>The <typeparamref name="TEntity"/> updated.</returns>
+        private TEntity DynamicUpdateFrom<TModel>(
+            TEntity baseEntity,
+            TModel model,
+            UpsertType upsertType)
+        {
+            IsModelAssignable<TModel>();
+
+            var entityType = baseEntity.GetType();
+
+            var updateFromMethods = entityType
+                .GetMethods()
+                .Where(m => m.Name.Equals("UpdateFrom", StringComparison.OrdinalIgnoreCase));
+
+            var actualUpdateFromMethod = updateFromMethods
+                .SingleOrDefault(m => m.GetParameters()
+                    .Any(p => p.ParameterType == typeof(TModel)));
+
+            actualUpdateFromMethod?.Invoke(baseEntity, new object[] { model, new EntityUpdateOptions(upsertType) });
+            return baseEntity;
+        }
+
+        /// <summary>
+        /// Base constructor responsible for obtaining required services through DI.
+        /// </summary>
+        /// <param name="repository"></param>
+        /// <param name="unitOfWork"></param>
+        public TableDataServiceV2(
+            IRepository<TEntity, TIdentifier> repository,
+            IUnitOfWork unitOfWork)
+            : base(repository, unitOfWork)
+        {
+        }
+
+        /// <summary>
+        /// Base constructor responsible for obtaining required services through DI.
+        /// </summary>
+        public TableDataServiceV2(
+            IRepository<TEntity, TIdentifier> repository,
+            IUnitOfWork unitOfWork,
+            Domain.Abstractions.IHandler<Notification> notificationsHandler)
+            : base(repository, unitOfWork, notificationsHandler)
+        {
+        }
+
+        /// <summary>
+        /// Cast the <typeparamref name="TEntity"/> into a <typeparamref name="TEntity"/> using reflection.
+        /// </summary>
+        /// <param name="entity">Entity to be casted.</param>
+        /// <typeparam name="TModel">Model to cast to.</typeparam>
+        /// <returns>The <typeparamref name="TModel"/> casted from an <typeparamref name="TEntity"/>.</returns>
+        /// <exception cref="NotAssignableException"><typeparamref name="TModel"/> is not assignable.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="entity"/> must not be null.</exception>
+        protected internal virtual TModel ToModel<TModel>(TEntity entity)
+           where TModel : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModel>();
+
+            if (entity == null)
+            {
+                throw new ArgumentNullException(nameof(entity), "Entity must not be null.");
+            }
+
+            var entityType = typeof(TEntity);
+            var modelType = typeof(TModel);
+
+            var entityProps = entityType.GetProperties()
+                .Where(prop => prop.SetMethod != null);
+            var modelProps = modelType.GetProperties()
+                .Where(prop => prop.SetMethod != null);
+
+            var result = new TModel();
+            Parallel.ForEach(entityProps, (source, state, index) =>
+            {
+                var modelProp = modelProps.SingleOrDefault(prop => prop.Name.Equals(source.Name));
+                modelProp?.SetValue(result, source.GetValue(entity));
+            });
+
+            return result;
+        }
+
+        protected internal virtual IQueryable<TModel> Projection<TModel>(
+            IQueryable<TEntity> entities)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModel>();
+            return entities.Project().To<TModel>();
+        }
+
+        /// <summary>
+        /// Cast the <typeparamref name="TEntity"/> into a <typeparamref name="TModel"/>.
+        /// </summary>
+        /// <param name="model">Model to be casted.</param>
+        /// <param name="upsertType">Upsert type to be called inside the <see cref="IEntityUpdate{TSource}.UpdateFrom(TSource, EntityUpdateOptions)"/> method.</param>
+        /// <typeparam name="TModel">Model type.</typeparam>
+        /// <returns>The <typeparamref name="TEntity"/>.</returns>
+        /// <exception cref="NotAssignableException"><typeparamref name="TModel"/> is not assignable.</exception>
+        protected internal virtual TEntity ToEntity<TModel>(
+            TModel model,
+            UpsertType upsertType)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModel>();
+            return DynamicUpdateFrom(Entity.Create<TEntity>(), model, upsertType);
+        }
+
+        private async Task<TEntity> EntityUpdateInternalAsync<TModel>(
+            TEntity entity, TModel model)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModel>();
+            if (entity == null)
+            {
+                RaiseNotification(Notification.FromType(GetType(), "Entity is null"));
+            }
+
+            DynamicUpdateFrom(entity, model, UpsertType.Update);
+            entity.UpdateUpdateAt();
+
+            entity = await Repository.EditAsync(entity);
+
+            if (!await CommitAsync())
+            {
+                RaiseNotification(Notification.FromType(GetType(), "Transaction was not commited"));
+            }
+            return entity;
+        }
+
+        protected virtual async Task<TModel> UpdateInternalAsync<TModel>(
+            TEntity entity,
+            TModel model)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            var entityResult = await EntityUpdateInternalAsync(entity, model);
+            return ToModel<TModel>(entityResult);
+        }
+
+        protected virtual async Task<TModelOut> UpdateInternalAsync<TModelIn, TModelOut>(
+            TEntity entity, TModelIn model)
+            where TModelIn : class, IEntity<TIdentifier>, new()
+            where TModelOut : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModelIn>();
+            IsModelAssignable<TModelOut>();
+            var entityResult = await EntityUpdateInternalAsync(entity, model);
+            return ToModel<TModelOut>(entityResult);
+        }
+
+        private async Task<TEntity> EntityCreate<TModel>(
+            TModel model)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModel>();
+            var entity = ToEntity(model, UpsertType.Insert);
+            await GenerateId(entity);
+
+            entity.UpdateCreatedAt();
+            await Repository.AddAsync(entity);
+
+            if (!await CommitAsync())
+            {
+                RaiseNotification(Notification.FromType(GetType(), "Transaction was not commited"));
+            }
+
+            return (entity);
+        }
+
+        public virtual async Task<TModel> Create<TModel>(
+            TModel model)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            var result = await EntityCreate(model);
+            return ToModel<TModel>(result);
+        }
+
+        public virtual async Task<TModelOut> Create<TModelIn, TModelOut>(
+            TModelIn model)
+            where TModelIn : class, IEntity<TIdentifier>, new()
+            where TModelOut : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModelOut>();
+            var result = await EntityCreate(model);
+            return ToModel<TModelOut>(result);
+        }
+
+        public virtual async Task<TModelOut> UpdateAsync<TModelIn, TModelOut>(
+            TModelIn model, Expression<Func<TEntity, bool>> customPredicate = null)
+            where TModelIn : class, IEntity<TIdentifier>, new()
+            where TModelOut : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModelIn>();
+            IsModelAssignable<TModelOut>();
+            var entity = customPredicate != null ? await FindByAsync(customPredicate) : await FindByIdAsync(model.Id);
+
+            if (entity == null)
+            {
+                RaiseNotification(Notification.FromType(GetType(), "Entity not found"));
+            }
+
+            return await UpdateInternalAsync<TModelIn, TModelOut>(entity, model);
+        }
+
+        public virtual async Task<TModel> UpsertAsync<TModel>(
+            TModel model,
+            Expression<Func<TEntity, bool>> customPredicate = null)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModel>();
+            var entity = customPredicate != null ? await FindByAsync(customPredicate) : await FindByIdAsync(model.Id);
+
+            if (entity == null)
+            {
+                return await Create(model);
+            }
+            else
+            {
+                return await UpdateInternalAsync(entity, model);
+            }
+        }
+
+        public virtual async Task<TModelOut> UpsertAsync<TModelIn, TModelOut>(
+            TModelIn model,
+            Expression<Func<TEntity, bool>> customPredicate = null)
+            where TModelIn : class, IEntity<TIdentifier>, new()
+            where TModelOut : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModelIn>();
+            IsModelAssignable<TModelOut>();
+            var entity = customPredicate != null ? await FindByAsync(customPredicate) : await FindByIdAsync(model.Id);
+
+            if (entity == null)
+            {
+                return await Create<TModelIn, TModelOut>(model);
+            }
+            else
+            {
+                return await UpdateInternalAsync<TModelIn, TModelOut>(entity, model);
+            }
+        }
+
+        public virtual async Task<TModel> GetById<TModel>(
+            TIdentifier id)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModel>();
+            var entity = await FindByIdAsync(id);
+
+            if (entity == null)
+            {
+                RaiseNotification(Notification.FromType(GetType(), "Entity not found"));
+            }
+
+            return ToModel<TModel>(entity);
+        }
+
+        public virtual async Task<TModel> Delete<TModel>(
+            TIdentifier id)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModel>();
+            var entity = await FindByIdAsync(id);
+
+            if (entity == null)
+            {
+                RaiseNotification(Notification.FromType(GetType(), "Entity not found"));
+            }
+
+            if (!UseSoftDelete)
+            {
+                await Repository.RemoveAsync(entity);
+            }
+            else
+            {
+                entity.Deleted = true;
+                entity = await Repository.EditAsync(entity);
+            }
+
+            if (!await CommitAsync())
+            {
+                RaiseNotification(Notification.FromType(GetType(), "Transaction was not commited"));
+            }
+
+            return ToModel<TModel>(entity);
+        }
+
+        protected internal virtual IQueryable<TModel> Project<TModel>(
+            IQueryable<TEntity> entities)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModel>();
+            var entityQuery = entities;
+            var projectedQuery = Projection<TModel>(entityQuery);
+            return projectedQuery;
+        }
+
+        public virtual IQueryable<TModel> GetAll<TModel>(
+            IQueryable<TEntity> adptedEntities = null)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            IsModelAssignable<TModel>();
+            var entityQuery = adptedEntities ?? GetEntities();
+
+            if (UseSoftDelete)
+            {
+                entityQuery = entityQuery.Where(x => !x.Deleted);
+            }
+
+            if (Ordering != null)
+            {
+                entityQuery = Ordering.Invoke(entityQuery);
+            }
+
+            return Project<TModel>(entityQuery);
+        }
+    }
+}

--- a/src/Core/Naylah.Core/Data/Services/TableDataServiceWrapper.cs
+++ b/src/Core/Naylah.Core/Data/Services/TableDataServiceWrapper.cs
@@ -10,8 +10,7 @@ namespace Naylah.Data
         where TEntity : class, IEntity<TIdentifier>, IModifiable, IEntityUpdate<TModel>, new()
         where TModel : class, IEntity<TIdentifier>, new()
     {
-        private readonly TableDataService<TEntity, TModel, TIdentifier> tableDataService;
-
+        protected readonly TableDataService<TEntity, TModel, TIdentifier> tableDataService;
 
         public TableDataServiceWrapper(TableDataService<TEntity, TModel, TIdentifier> tableDataService)
         {


### PR DESCRIPTION
### - Added classes TableServiceV2, StringTableDataServiceV2, PersonServiceV2 (playground), NotAssignableException.

#### Problem:
every time you need to have a different output model on get/upsert result you had to create another service that implement the tableservice constraining the entire service into using a single model.

#### Solution:
added a service (TableServicev2, StringTableServiceV2) that has methods with a ModelIn and ModelOut constraints, removing the need to constrain the service, but constraining the method.

#### Example:
```
// A get method constraining a PersonGetRequest
[HttpGet("")]
public IEnumerable<PersonGetRequest> GetPeople()
{
    return tableDataService.GetAll<PersonGetRequest>();
}

// A Post method that has the same ModelIn and ModelOut,
// meaning that the model which is going to be posted is the same that is going to be returned
[HttpPost("SameType")]
public async Task<PersonPostRequest> PostReturningSameType(
    [FromBody] PersonPostRequest person)
{
    return await tableDataService.UpsertAsync(person);
}

// A Post method with a different return model and posting object
[HttpPost("OtherType")]
public async Task<PersonGetRequest> PostReturningOtherType(
    [FromBody] PersonPostRequest person)
{
    return await tableDataService.UpsertAsync<PersonPostRequest, PersonGetRequest>(person);
}
```