### PR TITLE
table data service custom:

### DIFF
--- a/play/Naylah.ConsoleAspNetCore3/Controllers/AuthorController.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Controllers/AuthorController.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Naylah.ConsoleAspNetCore.DTOs;
+using Naylah.ConsoleAspNetCore.Entities;
+using Naylah.Data;
+
+namespace Naylah.ConsoleAspNetCore.Controllers
+{
+    [Route("api/[controller]"), ApiController]
+    public class AuthorController : ControllerBase
+    {
+        private readonly StringTableDataServiceCustom<Author> service;
+
+        public AuthorController(
+            StringTableDataServiceCustom<Author> service)
+        {
+            this.service = service;
+        }
+
+        // TODO: needs review on object mappings
+        [HttpGet("[action]")]
+        public IEnumerable<AuthorResponse> GetAuthorWithBooks()
+        {
+            return service.GetAll<AuthorResponse>();
+        }
+
+        [HttpGet("[action]")]
+        public IEnumerable<AuthorBaseResponse> GetAuthorBase()
+        {
+            return service.GetAll<AuthorBaseResponse>();
+        }
+
+        [HttpPost("[action]")]
+        public async Task<AuthorResponse> Upsert1(AuthorRequest author)
+        {
+            return await service.UpsertEntityAsync<AuthorRequest, AuthorResponse>(author);
+        }
+
+        [HttpPost("[action]")]
+        public async Task<AuthorBaseResponse> Upsert2(AuthorRequest author)
+        {
+            return await service.UpsertEntityAsync<AuthorRequest, AuthorResponse>(author);
+        }
+    }
+}

--- a/play/Naylah.ConsoleAspNetCore3/Controllers/BookController.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Controllers/BookController.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Naylah.ConsoleAspNetCore.DTOs;
+using Naylah.ConsoleAspNetCore.Entities;
+using Naylah.Data;
+
+namespace Naylah.ConsoleAspNetCore.Controllers
+{
+    [Route("api/[controller]"), ApiController]
+    public class BookController : ControllerBase
+    {
+        private readonly StringTableDataServiceCustom<Book> service;
+
+        public BookController(StringTableDataServiceCustom<Book> service)
+        {
+            this.service = service;
+        }
+
+        [HttpGet("[action]")]
+        public IEnumerable<BookResponse> GetBooksWithAuthor()
+        {
+            return service.GetAll<BookResponse>();
+        }
+
+        [HttpGet("[action]")]
+        public IEnumerable<BookBaseResponse> GetBooksBase()
+        {
+            return service.GetAll<BookBaseResponse>();
+        }
+
+        [HttpPost("[action]")]
+        public async Task<BookBaseResponse> Upsert1(
+            BookRequest book)
+        {
+            return await service.UpsertEntityAsync<BookRequest, BookBaseResponse>(book);
+        }
+
+        [HttpPost("[action]")]
+        public async Task<BookResponse> Upsert2(
+            BookRequest book)
+        {
+            return await service.UpsertEntityAsync<BookRequest, BookResponse>(book);
+        }
+    }
+}

--- a/play/Naylah.ConsoleAspNetCore3/Controllers/PersonControllerV2.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Controllers/PersonControllerV2.cs
@@ -16,32 +16,33 @@ namespace Naylah.ConsoleAspNetCore.Controllers
     [Route("api/[controller]"), ApiController]
     public class PersonControllerV2 : ControllerBase
     {
-        //private readonly PersonServiceV2 tableDataService;
+        private readonly StringTableDataServiceCustom<Person> tableDataService;
 
-        //public PersonControllerV2(
-        //    PersonServiceV2 tableDataService)
-        //{
-        //    this.tableDataService = tableDataService;
-        //}
+        public PersonControllerV2(
+           StringTableDataServiceCustom<Person> tableDataService)
+        {
+            this.tableDataService = tableDataService;
+        }
 
-        //[HttpGet("")]
-        //public IEnumerable<PersonGetRequest> GetPeople()
-        //{
-        //    return tableDataService.GetAll<PersonGetRequest>();
-        //}
+        [HttpGet("")]
+        public IEnumerable<PersonGetRequest> GetPeople()
+        {
+            return tableDataService.GetAll<PersonGetRequest>();
+        }
 
-        //[HttpPost("SameType")]
-        //public async Task<PersonPostRequest> PostReturningSameType(
-        //    [FromBody] PersonPostRequest person)
-        //{
-        //    return await tableDataService.UpsertAsync<Person, PersonPostRequest>(person);
-        //}
+        [HttpPost("SameType")]
+        public async Task<PersonPostRequest> PostReturningSameType(
+           [FromBody] PersonPostRequest person)
+        {
+            return await tableDataService.UpsertEntityAsync(person).ConfigureAwait(false);
+        }
 
-        //[HttpPost("OtherType")]
-        //public async Task<PersonPostRequest> PostReturningOtherType(
-        //    [FromBody] PersonPostRequest person)
-        //{
-        //    return await tableDataService.UpsertAsync<Person, PersonPostRequest>(person);
-        //}
+        [HttpPost("OtherType")]
+        public async Task<PersonGetRequest> PostReturningOtherType(
+           [FromBody] PersonPostRequest person)
+        {
+            return await tableDataService.UpsertEntityAsync<PersonPostRequest, PersonGetRequest>(person)
+                .ConfigureAwait(false);
+        }
     }
 }

--- a/play/Naylah.ConsoleAspNetCore3/DTOs/AuthorDTO.cs
+++ b/play/Naylah.ConsoleAspNetCore3/DTOs/AuthorDTO.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace Naylah.ConsoleAspNetCore.DTOs
+{
+    public class AuthorBaseResponse : IEntity<string>
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class AuthorRequest : AuthorBaseResponse
+    {
+        public DateTime BirthDate { get; set; }
+    }
+
+    // TODO: needs review on object mappings
+    public class AuthorResponse : AuthorBaseResponse
+    {
+        public ICollection<BookResponse> Books { get; set; }
+    }
+}

--- a/play/Naylah.ConsoleAspNetCore3/DTOs/BookDTO.cs
+++ b/play/Naylah.ConsoleAspNetCore3/DTOs/BookDTO.cs
@@ -1,0 +1,22 @@
+namespace Naylah.ConsoleAspNetCore.DTOs
+{
+    public class BookBaseResponse : IEntity<string>
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+        public int ReleasedYear { get; set; }
+    }
+
+    public class BookRequest : IEntity<string>
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+        public int ReleasedYear { get; set; }
+        public string AuthorId { get; set; }
+    }
+
+    public class BookResponse : BookBaseResponse
+    {
+        public AuthorBaseResponse Author { get; set; }
+    }
+}

--- a/play/Naylah.ConsoleAspNetCore3/Entities/Author.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Entities/Author.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Naylah.ConsoleAspNetCore.DTOs;
+
+namespace Naylah.ConsoleAspNetCore.Entities
+{
+    public class Author :
+        IEntity<string>,
+        IModifiable,
+        IEntityUpdate<AuthorRequest>
+    {
+        public string Name { get; set; }
+        public DateTime BirthDate { get; set; }
+        public ICollection<Book> Books { get; set; }
+        public string Id { get; set; }
+        public DateTimeOffset? CreatedAt { get; set; }
+        public DateTimeOffset? UpdatedAt { get; set; }
+        public string Version { get; set; }
+        public bool Deleted { get; set; }
+
+        internal static void EntityConfigure(
+            ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Author>()
+                .HasMany(m => m.Books)
+                .WithOne(o => o.Author)
+                .HasForeignKey(fk => fk.AuthorId);
+        }
+
+        public void UpdateFrom(AuthorRequest source, EntityUpdateOptions options = null)
+        {
+            this.Name = source.Name;
+            this.BirthDate = source.BirthDate;
+        }
+    }
+}

--- a/play/Naylah.ConsoleAspNetCore3/Entities/Book.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Entities/Book.cs
@@ -1,0 +1,41 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Naylah.ConsoleAspNetCore.DTOs;
+
+namespace Naylah.ConsoleAspNetCore.Entities
+{
+    public class Book :
+        IEntity<string>,
+        IModifiable,
+        IEntityUpdate<BookRequest>
+    {
+        public string Title { get; set; }
+        public string AuthorId { get; set; }
+        public Author Author { get; set; }
+        public int ReleasedYear { get; set; }
+        public string Id { get; set; }
+        public DateTimeOffset? CreatedAt { get; set; }
+        public DateTimeOffset? UpdatedAt { get; set; }
+        public string Version { get; set; }
+        public bool Deleted { get; set; }
+
+        internal static void EntityConfigure(
+            ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Book>()
+                .Property(p => p.Title)
+                .IsRequired();
+
+            modelBuilder.Entity<Book>()
+                .Property(p => p.AuthorId)
+                .IsRequired();
+        }
+
+        public void UpdateFrom(BookRequest source, EntityUpdateOptions options = null)
+        {
+            this.Title = source.Title;
+            this.AuthorId = source.AuthorId;
+            this.ReleasedYear = source.ReleasedYear;
+        }
+    }
+}

--- a/play/Naylah.ConsoleAspNetCore3/Migrations/20210316143630_BookAuthor.Designer.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Migrations/20210316143630_BookAuthor.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Naylah.ConsoleAspNetCore.ORM;
 
 namespace Naylah.ConsoleAspNetCore.Migrations
 {
     [DbContext(typeof(TestDbContext))]
-    partial class TestDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210316143630_BookAuthor")]
+    partial class BookAuthor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/play/Naylah.ConsoleAspNetCore3/Migrations/20210316143630_BookAuthor.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Migrations/20210316143630_BookAuthor.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Naylah.ConsoleAspNetCore.Migrations
+{
+    public partial class BookAuthor : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Author",
+                schema: "Test",
+                columns: table => new
+                {
+                    Id = table.Column<string>(nullable: false),
+                    Name = table.Column<string>(nullable: true),
+                    BirthDate = table.Column<DateTime>(nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(nullable: true),
+                    Version = table.Column<string>(nullable: true),
+                    Deleted = table.Column<bool>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Author", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Book",
+                schema: "Test",
+                columns: table => new
+                {
+                    Id = table.Column<string>(nullable: false),
+                    Title = table.Column<string>(nullable: false),
+                    AuthorId = table.Column<string>(nullable: false),
+                    ReleasedYear = table.Column<int>(nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(nullable: true),
+                    UpdatedAt = table.Column<DateTimeOffset>(nullable: true),
+                    Version = table.Column<string>(nullable: true),
+                    Deleted = table.Column<bool>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Book", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Book_Author_AuthorId",
+                        column: x => x.AuthorId,
+                        principalSchema: "Test",
+                        principalTable: "Author",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Book_AuthorId",
+                schema: "Test",
+                table: "Book",
+                column: "AuthorId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Book",
+                schema: "Test");
+
+            migrationBuilder.DropTable(
+                name: "Author",
+                schema: "Test");
+        }
+    }
+}

--- a/play/Naylah.ConsoleAspNetCore3/Naylah.ConsoleAspNetCore3.csproj
+++ b/play/Naylah.ConsoleAspNetCore3/Naylah.ConsoleAspNetCore3.csproj
@@ -12,6 +12,10 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.10">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.10" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.6.3" />

--- a/play/Naylah.ConsoleAspNetCore3/ORM/TestDbContext.cs
+++ b/play/Naylah.ConsoleAspNetCore3/ORM/TestDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
 using Naylah.ConsoleAspNetCore.Entities;
 using System;
 using System.Collections.Generic;
@@ -18,14 +19,21 @@ namespace Naylah.ConsoleAspNetCore.ORM
 
         }
 
-        public TestDbContext(DbContextOptions<TestDbContext> options) : base(options)
+        public TestDbContext(
+            DbContextOptions<TestDbContext> options) : base(options)
         {
         }
 
         public TestDbContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<TestDbContext>();
-            optionsBuilder.UseSqlServer("Server=(localdb)\\MSSQLLocalDB;Database=NaylahTestDevDB;Trusted_Connection=True;MultipleActiveResultSets=false", ConfigureDBContext);
+            IConfiguration configuration = new ConfigurationBuilder()
+                .SetBasePath(AppContext.BaseDirectory)
+                .AddJsonFile("appsettings.Development.json")
+                .Build();
+
+            var connectionString = configuration.GetConnectionString("LocalDB");
+            optionsBuilder.UseSqlServer(connectionString, ConfigureDBContext);
 
             return new TestDbContext(optionsBuilder.Options);
         }
@@ -35,6 +43,9 @@ namespace Naylah.ConsoleAspNetCore.ORM
             modelBuilder.HasDefaultSchema(schema);
 
             modelBuilder.Entity<Person>().HasKey(x => x.Id);
+
+            Author.EntityConfigure(modelBuilder);
+            Book.EntityConfigure(modelBuilder);
         }
 
         internal static void ConfigureDBContext(SqlServerDbContextOptionsBuilder obj)

--- a/play/Naylah.ConsoleAspNetCore3/Startup.cs
+++ b/play/Naylah.ConsoleAspNetCore3/Startup.cs
@@ -84,17 +84,21 @@ namespace Naylah.ConsoleAspNetCore
 
             });
 
-
+            var connectionString = Configuration.GetConnectionString("LocalDB");
             services.
-                AddDbContext<ORM.TestDbContext>(options => options.UseSqlServer("Server=(localdb)\\MSSQLLocalDB;Database=NaylahTestDevDB;Trusted_Connection=True;MultipleActiveResultSets=false", ORM.TestDbContext.ConfigureDBContext))
+                AddDbContext<ORM.TestDbContext>(options => options.UseSqlServer(connectionString, ORM.TestDbContext.ConfigureDBContext))
             ;
 
             //services.AddSingleton(new List<Person>());
             //services.AddScoped<IRepository<Person, string>, SomeRepository>();
 
             services.AddEntityFrameworkRepository<ORM.TestDbContext, Person, string>();
+            services.AddEntityFrameworkRepository<ORM.TestDbContext, Book, string>();
+            services.AddEntityFrameworkRepository<ORM.TestDbContext, Author, string>();
 
             services.AddScoped(typeof(StringAppTableDataService<,>));
+            services.AddScoped(typeof(StringTableDataServiceCustom<>));
+            services.AddScoped(typeof(TableDataServiceCustom<,>));
             services.AddScoped<IUnitOfWork, SomeWorker>();
 
             services.AddScoped<PersonService>();

--- a/play/Naylah.ConsoleAspNetCore3/appsettings.Development.json
+++ b/play/Naylah.ConsoleAspNetCore3/appsettings.Development.json
@@ -5,5 +5,8 @@
       "Microsoft": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "ConnectionStrings": {
+    "LocalDB": "Server=(localdb)\\MSSQLLocalDB;Database=NaylahTestDevDB;Trusted_Connection=True;MultipleActiveResultSets=false",
   }
 }

--- a/src/Core/Naylah.Core/Data/Extensions/QueryableExtensions.cs
+++ b/src/Core/Naylah.Core/Data/Extensions/QueryableExtensions.cs
@@ -66,6 +66,7 @@ namespace Naylah.Data.Extensions
         {
             var sourceProperty = sourceProperties.FirstOrDefault(src => src.Name == destinationProperty.Name);
 
+            // TODO: needs review on object mappings
             if (sourceProperty != null)
             {
                 return Expression.Bind(destinationProperty, Expression.Property(parameterExpression, sourceProperty));

--- a/src/Core/Naylah.Core/Data/Services/StringTableDataServiceCustom.cs
+++ b/src/Core/Naylah.Core/Data/Services/StringTableDataServiceCustom.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+
+namespace Naylah.Data
+{
+    public class StringTableDataServiceCustom<TEntity>
+        : TableDataServiceCustom<TEntity, string>
+        where TEntity : class, IEntity<string>, IModifiable, new()
+    {
+        public StringTableDataServiceCustom(
+            IRepository<TEntity, string> repository,
+            Access.IUnitOfWork unitOfWork)
+            : base(repository, unitOfWork)
+        {
+        }
+
+        public StringTableDataServiceCustom(
+            IRepository<TEntity, string> repository,
+            Access.IUnitOfWork unitOfWork,
+            Domain.Abstractions.IHandler<Notification> notificationsHandler)
+            : base(repository, unitOfWork, notificationsHandler)
+        {
+        }
+
+        protected override async Task<TEntity> FindByIdAsync(string identifier)
+        {
+            return await FindByAsync(x => x.Id.Equals(identifier));
+        }
+
+        protected internal override async Task GenerateId(TEntity entity)
+        {
+            entity.GenerateId(true);
+        }
+    }
+}

--- a/src/Core/Naylah.Core/Data/Services/TableDataServiceBase.cs
+++ b/src/Core/Naylah.Core/Data/Services/TableDataServiceBase.cs
@@ -9,11 +9,18 @@ namespace Naylah.Data
     public abstract class TableDataServiceBase<TEntity, TIdentifier> : QueryDataService<TEntity, TIdentifier>
         where TEntity : class, IEntity<TIdentifier>, IModifiable, new()
     {
-        public TableDataServiceBase(IRepository<TEntity, TIdentifier> repository, IUnitOfWork unitOfWork) : base(repository, unitOfWork)
+        protected TableDataServiceBase(
+            IRepository<TEntity, TIdentifier> repository, 
+            IUnitOfWork unitOfWork)
+            : base(repository, unitOfWork)
         {
         }
 
-        public TableDataServiceBase(IRepository<TEntity, TIdentifier> repository, IUnitOfWork unitOfWork, IHandler<Notification> notificationsHandler) : base(repository, unitOfWork, notificationsHandler)
+        protected TableDataServiceBase(
+            IRepository<TEntity, TIdentifier> repository,
+            IUnitOfWork unitOfWork,
+            IHandler<Notification> notificationsHandler)
+            : base(repository, unitOfWork, notificationsHandler)
         {
         }
 
@@ -40,7 +47,6 @@ namespace Naylah.Data
 
         internal abstract TEntity UpdateEntity(TEntity entity, object model, UpsertType upsertType);
 
-
         internal abstract Task<TCustomModel> CreateAsync<TCustomModel>(TCustomModel model)
             where TCustomModel : class, IEntity<TIdentifier>, new();
 
@@ -56,7 +62,6 @@ namespace Naylah.Data
         internal abstract Task<TCustomModel> DeleteAsync<TCustomModel>(TCustomModel model)
             where TCustomModel : class, IEntity<TIdentifier>, new();
 
-        
         protected virtual async Task<TEntity> CreateInternalAsync(TEntity entity)
         {
             if (entity == null)

--- a/src/Core/Naylah.Core/Data/Services/TableDataServiceCustom.cs
+++ b/src/Core/Naylah.Core/Data/Services/TableDataServiceCustom.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace Naylah.Data
+{
+    public class TableDataServiceCustom<TEntity, TIdentifier>
+        : TableDataServiceBase<TEntity, TIdentifier>
+        where TEntity : class, IEntity<TIdentifier>, IModifiable, new()
+    {
+        public TableDataServiceCustom(
+            IRepository<TEntity, TIdentifier> repository,
+            Access.IUnitOfWork unitOfWork)
+            : base(repository, unitOfWork)
+        {
+        }
+
+        public TableDataServiceCustom(
+            IRepository<TEntity, TIdentifier> repository,
+            Access.IUnitOfWork unitOfWork,
+            Domain.Abstractions.IHandler<Notification> notificationsHandler)
+            : base(repository, unitOfWork, notificationsHandler)
+        {
+        }
+
+        private void ValidateModel<TCustomModel>()
+        {
+            if (!typeof(IEntityUpdate<TCustomModel>).IsAssignableFrom(typeof(TEntity)))
+                throw new NotAssignableException($"Cannot assign {nameof(TEntity)} into {nameof(IEntityUpdate<TCustomModel>)}");
+        }
+
+        public virtual IQueryable<TCustomModel> GetAll<TCustomModel>()
+            where TCustomModel : class, IEntity<TIdentifier>, new()
+        {
+            return base.GetAll<TCustomModel>(base.GetEntities());
+        }
+
+        public new virtual async Task<TCustomModel> GetByIdAsync<TCustomModel>(
+            TIdentifier id)
+            where TCustomModel : class, IEntity<TIdentifier>, new()
+        {
+            return await base.GetByIdAsync<TCustomModel>(id);
+        }
+
+        public virtual async Task<TCustomModel> FindByAsync<TCustomModel>(
+            Expression<Func<TEntity, bool>> @where)
+            where TCustomModel : class, IEntity<TIdentifier>, new()
+        {
+            var entity = await base.FindByAsync(where);
+            return ToModel<TCustomModel>(entity);
+        }
+
+        public virtual async Task<TModel> CreateEntityAsync<TModel>(
+            TModel model)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            return await this.CreateAsync(model);
+        }
+
+        public virtual async Task<TModelOut> CreateEntityAsync<TModelIn, TModelOut>(
+            TModelIn model)
+            where TModelIn : class, IEntity<TIdentifier>, new()
+            where TModelOut : class, IEntity<TIdentifier>, new()
+        {
+            var createdEntity = await CreateAsync(model);
+            var result = await this.FindByIdAsync(createdEntity.Id);
+
+            return ToModel<TModelOut>(result);
+        }
+
+        public virtual async Task<TModel> UpdateEntityAsync<TModel>(
+            TModel model,
+            Expression<Func<TEntity, bool>> @where)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            return await this.UpdateAsync(model, where);
+        }
+
+        public virtual async Task<TModel> UpdateEntityAsync<TModel>(
+            TModel model)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            return await this.UpdateAsync(model, null);
+        }
+
+        public virtual async Task<TModelOut> UpdateEntityAsync<TModelIn, TModelOut>(
+            TModelIn model,
+            Expression<Func<TEntity, bool>> @where)
+            where TModelIn : class, IEntity<TIdentifier>, new()
+            where TModelOut : class, IEntity<TIdentifier>, new()
+        {
+            var updatedEntity = await UpdateAsync(model, where);
+            var result = await this.FindByIdAsync(updatedEntity.Id);
+
+            return ToModel<TModelOut
+            >(result);
+        }
+        public virtual async Task<TModelOut> UpdateEntityAsync<TModelIn, TModelOut>(
+            TModelIn model)
+            where TModelIn : class, IEntity<TIdentifier>, new()
+            where TModelOut : class, IEntity<TIdentifier>, new()
+        {
+            return await this.UpdateEntityAsync<TModelIn, TModelOut>(model, null);
+        }
+
+        public virtual async Task<TModel> UpsertEntityAsync<TModel>(
+            TModel model,
+            Expression<Func<TEntity, bool>> @where)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            return await this.UpsertAsync(model, where);
+        }
+
+        public virtual async Task<TModel> UpsertEntityAsync<TModel>(
+            TModel model)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            return await this.UpsertAsync(model, null);
+        }
+
+        public virtual async Task<TModelOut> UpsertEntityAsync<TModelIn, TModelOut>(
+            TModelIn model,
+            Expression<Func<TEntity, bool>> @where)
+            where TModelIn : class, IEntity<TIdentifier>, new()
+            where TModelOut : class, IEntity<TIdentifier>, new()
+        {
+            var updatedEntity = await UpsertAsync(model, where);
+            var result = await this.FindByIdAsync(updatedEntity.Id);
+
+            return ToModel<TModelOut>(result);
+        }
+
+        public virtual async Task<TModelOut> UpsertEntityAsync<TModelIn, TModelOut>(
+            TModelIn model)
+            where TModelIn : class, IEntity<TIdentifier>, new()
+            where TModelOut : class, IEntity<TIdentifier>, new()
+        {
+            return await this.UpsertEntityAsync<TModelIn, TModelOut>(model, null);
+        }
+
+        public virtual async Task<TModel> DeleteEntityAsync<TModel>(
+            TModel model)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            return await this.DeleteAsync(model);
+        }
+
+        public virtual async Task<TModel> DeleteEntityAsync<TModel>(
+            TIdentifier id)
+            where TModel : class, IEntity<TIdentifier>, new()
+        {
+            return await this.DeleteAsync<TModel>(id);
+        }
+
+        internal override TEntity UpdateEntity(
+            TEntity entity, object model, UpsertType upsertType)
+        {
+            var entityType = entity.GetType();
+
+            var updateFromMethods = entityType.GetMethods()
+                .Where(w => w.Name.Equals("UpdateFrom", StringComparison.OrdinalIgnoreCase));
+
+            var actualUpdateFromMethod = updateFromMethods
+                .SingleOrDefault(m => m.GetParameters()
+                                        .Any(p => p.ParameterType == model.GetType()));
+
+            actualUpdateFromMethod?.Invoke(entity, new object[] { model, new EntityUpdateOptions(upsertType) });
+            return entity;
+        }
+
+        internal override async Task<TCustomModel> DeleteAsync<TCustomModel>(
+            TIdentifier identifier)
+        {
+            ValidateModel<TCustomModel>();
+
+            var model = await base.GetByIdAsync<TCustomModel>(identifier);
+
+            return await DeleteAsync(model);
+        }
+
+        internal override async Task<TCustomModel> DeleteAsync<TCustomModel>(
+            TCustomModel model)
+        {
+            ValidateModel<TCustomModel>();
+
+            var entity = UpdateEntity(
+                Activator.CreateInstance<TEntity>(),
+                model, UpsertType.Instance);
+            entity.Id = model.Id;
+
+            await base.DeleteInternal(entity);
+            return model;
+        }
+
+        internal override async Task<TCustomModel> CreateAsync<TCustomModel>(
+            TCustomModel model)
+        {
+            ValidateModel<TCustomModel>();
+
+            var entity = UpdateEntity(
+                Activator.CreateInstance<TEntity>(),
+                model, UpsertType.Insert);
+
+            await base.GenerateId(entity);
+            entity = await base.CreateInternalAsync(entity);
+
+            if (!await CommitAsync())
+            {
+                RaiseNotification(Notification.FromType(GetType(), "Transaction was not commited"));
+            }
+
+            return ToModel<TCustomModel>(entity);
+        }
+
+        internal override async Task<TCustomModel> UpdateAsync<TCustomModel>(
+            TCustomModel model,
+            Expression<Func<TEntity, bool>> customPredicate = null)
+        {
+            ValidateModel<TCustomModel>();
+
+            var entity = customPredicate != null ?
+                await FindByAsync(customPredicate)
+                : await FindByIdAsync(model.Id);
+
+            if (entity == null)
+            {
+                RaiseNotification(Notification.FromType(GetType(), "Entity not found"));
+            }
+
+            UpdateEntity(entity, model, UpsertType.Update);
+
+            if (!await CommitAsync())
+            {
+                RaiseNotification(Notification.FromType(GetType(), "Transaction was not commited"));
+            }
+
+            entity = await base.UpdateInternalAsync(entity);
+            return ToModel<TCustomModel>(entity);
+        }
+
+        internal override async Task<TCustomModel> UpsertAsync<TCustomModel>(
+            TCustomModel model,
+            Expression<Func<TEntity, bool>> customPredicate = null)
+        {
+            var entity = customPredicate != null ?
+                await FindByAsync(customPredicate)
+                : await FindByIdAsync(model.Id);
+
+            if (entity == null)
+            {
+                entity = CreateEntity(model, UpsertType.Insert);
+                await GenerateId(entity);
+
+                entity = await CreateInternalAsync(entity);
+            }
+            else
+            {
+                UpdateEntity(entity, model, UpsertType.Update);
+
+                entity = await UpdateInternalAsync(entity);
+            }
+
+            if (!await CommitAsync())
+            {
+                RaiseNotification(Notification.FromType(GetType(), "Transaction was not commited"));
+            }
+
+            return ToModel<TCustomModel>(entity);
+        }
+    }
+}


### PR DESCRIPTION
**Rewritten TableServiceV2** => (#3)

**SOURCE:**
- Added _TableDataServiceCustom_ which contains methods to insert/update a DTO type and return a different one.
`TModelOutput result = service.UpsertEntityAsync<TModelOutput, TModelInput>(input);`
- Added _StringTableDataServiceCustom_ which implements _TableDataServiceCustom_ but type its Identifier to a string.
- **KNOWN ERRORS:** When a TModelOut has another DTO inside it throws an _ArgumentException_ on _QueryableExtensions.BuildBinding_ on line 72. Need a review on this binding method.

**PLAYGROUND**
- Added new entities to play with  (_Author_/_Book_).
- Now obtains database _connectionString_ through _appsettings_ instead of hardcoding it.